### PR TITLE
Se utiliza token para payload en controladores

### DIFF
--- a/api/src/middleware/verifyToken.ts
+++ b/api/src/middleware/verifyToken.ts
@@ -24,9 +24,7 @@ export const authenticateToken = async (req: Request, res: Response, next: NextF
   try {
     const token = req.cookies[API_TOKEN_NAME] as string;
 
-    if (!token) {
-      return res.status(401).json({ message: 'No token provided' });
-    }
+    if (!token) return res.status(401).json({ message: 'No token provided' })
 
     const user = await verifyToken(token);
     req.user = user;

--- a/api/src/utils/fnCumMesAct.ts
+++ b/api/src/utils/fnCumMesAct.ts
@@ -461,15 +461,15 @@ function parsearInfoArrayServired(data: MesActServired){
 }
 
 
-export function ReturnCompanyAtriCumMesActu(zona: string) {
-  if (zona === '39627') return MetasMesActMultired
-  if (zona === '39628') return MetasMesActServired
+export function ReturnCompanyAtriCumMesActu(zona: number) {
+  if (zona === 39627) return MetasMesActMultired
+  if (zona === 39628) return MetasMesActServired
 }
 
-export function ReturArrayCumpMesActProducts (zona: string, metas: MesActMultired | MesActServired) {
-  if (zona === '39627') {
+export function ReturArrayCumpMesActProducts (zona: number, metas: MesActMultired | MesActServired) {
+  if (zona === 39627) {
     return parsearInfoArrayMultired(metas as MesActMultired)
-  } else if(zona === '39628') {
+  } else if(zona === 39628) {
     return parsearInfoArrayServired(metas as MesActServired)
   }
   throw new Error('Error al parsear la informacion')

--- a/api/src/utils/fnMetasProducts.ts
+++ b/api/src/utils/fnMetasProducts.ts
@@ -340,15 +340,15 @@ const Multired = [
   `${PRM}RECAUDOS`, `${PRM}RECARGAS`, `${PRM}LV`,
 ]
 
-export function ReturnCompanyAtributesMetProducts(zona: string) {
-  if (zona === '39627') return Multired
-  if (zona === '39628') return Servired
+export function ReturnCompanyAtributesMetProducts(zona: number) {
+  if (zona === 39627) return Multired
+  if (zona === 39628) return Servired
 }
 
-export function ReturnArrayMetProducts(zona: string, metas: ProductsYumbo | ProductsJamundi) {
-  if (zona === '39627') {
+export function ReturnArrayMetProducts(zona: number, metas: ProductsYumbo | ProductsJamundi) {
+  if (zona === 39627) {
     return parsearInfoArrayMultired(metas as ProductsYumbo)
-  } else if (zona === '39628') {
+  } else if (zona === 39628) {
     return parsearInfoArrayServired(metas as ProductsJamundi)
   }
   throw new Error('Error al parsear la informacion')

--- a/client/src/hooks/useFetchData.ts
+++ b/client/src/hooks/useFetchData.ts
@@ -2,7 +2,7 @@ import { MetasProducto } from '../types/Metas'
 import { useEffect, useState } from 'react'
 import axios, { AxiosError } from 'axios'
 
-export function useFecthMetasData (url: string, company: string, codigo: string) {
+export function useFecthMetasData (url: string) {
   const [data, setData] = useState<MetasProducto[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<Error | null>(null)
@@ -12,7 +12,7 @@ export function useFecthMetasData (url: string, company: string, codigo: string)
     const fetchData = async () => {
       setIsLoading(true)
       try {
-        const response = await axios.get(url, { params: { zona: company, codigo } })
+        const response = await axios.get(url)
         setData(response.data)
         setError(null)
       } catch (err: AxiosError | Error | unknown) {
@@ -36,7 +36,7 @@ export function useFecthMetasData (url: string, company: string, codigo: string)
     const intervalId = setInterval(fetchData, 5 * 60 * 1000) // Fetch data every 5 minutes
 
     return () => clearInterval(intervalId) // Clean up on unmount
-  }, [url, company, codigo])
+  }, [url])
 
   return { data, isLoading, error, close }
 }

--- a/client/src/pages/ApsDia.tsx
+++ b/client/src/pages/ApsDia.tsx
@@ -6,9 +6,9 @@ import { useAuth } from '../auth/AuthContext'
 import { useMemo, useState } from 'react'
 
 function AspDiaPage() {
-  const { profileData, funLogOut } = useAuth()
+  const { funLogOut } = useAuth()
 
-  const { data, isLoading, close } = useFecthMetasData('/cumpDiaProd', profileData?.sucursal.ZONA!, profileData?.sucursal.CODIGO!)
+  const { data, isLoading, close } = useFecthMetasData('/cumpDiaProd')
   const [isAscending, setIsAscending] = useState(false)
 
   const sortedData = useMemo(() => {

--- a/client/src/pages/ApsMesAnt.tsx
+++ b/client/src/pages/ApsMesAnt.tsx
@@ -6,9 +6,9 @@ import { sortData } from '../utils/funtions'
 import { useMemo, useState } from 'react'
 
 function AspMenAntPage () {
-  const { profileData, funLogOut} = useAuth()
+  const { funLogOut} = useAuth()
 
-  const { data, isLoading, close } = useFecthMetasData('/cumpMesAnt', profileData?.sucursal.ZONA!, profileData?.sucursal.CODIGO!)
+  const { data, isLoading, close } = useFecthMetasData('/cumpMesAnt')
   const [isAscending, setIsAscending] = useState(false)
 
   const sortedData = useMemo(() => {

--- a/client/src/pages/AspMes.tsx
+++ b/client/src/pages/AspMes.tsx
@@ -6,9 +6,9 @@ import { HeaderComponent } from '../components/ui/headerComponent'
 import { useAuth } from '../auth/AuthContext'
 
 function AspMesPage () {
-  const { profileData, funLogOut} = useAuth()
+  const { funLogOut} = useAuth()
 
-  const { data, isLoading, close } = useFecthMetasData('/cumpMesAct', profileData?.sucursal.ZONA!, profileData?.sucursal.CODIGO!)
+  const { data, isLoading, close } = useFecthMetasData('/cumpMesAct')
   const [isAscending, setIsAscending] = useState(false)
 
   const sortedData = useMemo(() => {


### PR DESCRIPTION
se eliminan y refactorizan las rutas de metas en la API, en las cuales el código y la zona llegaban por parámetros y/o querys en la URL <----
- En cambio contando con el middlaware que valida la sesión y este a su vez tiene la información de la sucursal y la zona, se reutiliza está lógica para las diferentes consultas SQL realizadas con sequalize.